### PR TITLE
buildSrc

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="11">
+      <module name="AndoroidSamples.buildSrc" target="11" />
+      <module name="AndoroidSamples.buildSrc.main" target="11" />
+      <module name="AndoroidSamples.buildSrc.test" target="11" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/kotlinScripting.xml
+++ b/.idea/kotlinScripting.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinScriptingSettings">
+    <option name="suppressDefinitionsCheck" value="true" />
+  </component>
+</project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,10 +37,11 @@ android {
 
 dependencies {
 
-    implementation("androidx.core:core-ktx:1.8.0")
-    implementation("androidx.appcompat:appcompat:1.5.0")
-    implementation("com.google.android.material:material:1.6.1")
-    testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.3")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.4.0")
+    implementation(AndroidDependencies.KTX_CORE)
+    implementation(AndroidDependencies.COMPAT)
+    implementation(AndroidDependencies.GOOGLE_MATERIAL)
+
+    testImplementation(MainDependencies.JUNIT4)
+    androidTestImplementation(AndroidDependencies.JUNIT_ANDROID)
+    androidTestImplementation(AndroidDependencies.ESPRESSO)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "7.2.2" apply false
-    id ("com.android.library") version "7.2.2" apply false
-    id ("org.jetbrains.kotlin.android") version "1.7.10" apply false
+    id("com.android.application") version Android.ANDROID_PLUGINS apply false
+    id ("com.android.library") version Android.ANDROID_PLUGINS apply false
+    id ("org.jetbrains.kotlin.android") version MainLibs.KOTLIN apply false
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,4 +1,4 @@
-plugins{
+plugins {
     `kotlin-dsl`
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins{
+    `kotlin-dsl`
+}
+
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,17 @@
+import org.gradle.launcher.Main
+
+object MainDependencies {
+
+    const val JUNIT4 = "junit:junit:${MainLibs.JUNIT4}"
+
+}
+
+object AndroidDependencies {
+
+    const val KTX_CORE = "androidx.core:core-ktx:${Android.KTX_CORE}"
+    const val COMPAT = "androidx.appcompat:appcompat:${Android.COMPAT}"
+    const val GOOGLE_MATERIAL = "com.google.android.material:material:${Android.GOOGLE_MATERIAL}"
+    const val JUNIT_ANDROID = "androidx.test.ext:junit:${Android.JUNIT_ANDROID}"
+    const val ESPRESSO = "androidx.test.espresso:espresso-core:${Android.ESPRESSO}"
+
+}

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,3 +1,17 @@
 object MainLibs {
 
+    const val KOTLIN = "1.7.10"
+    const val JUNIT4 = "4.13.2"
+
+}
+
+object Android{
+
+    const val ANDROID_PLUGINS = "7.2.2"
+    const val KTX_CORE = "1.8.0"
+    const val COMPAT = "1.5.0"
+    const val GOOGLE_MATERIAL = "1.6.1"
+    const val JUNIT_ANDROID = "1.1.3"
+    const val ESPRESSO = "3.4.0"
+
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,3 @@
+object MainLibs {
+
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Aug 19 20:34:50 MSK 2022
+#Fri Aug 19 21:55:01 MSK 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,4 +13,4 @@ dependencyResolutionManagement {
     }
 }
 rootProject.name = "Andoroid Samples"
-include ':app'
+include(":app")


### PR DESCRIPTION
Basic dependencies managment approach implemented
Versions.kt - contains info about versions for both libs and plugins
Dependencies.kt - containst concrete dependencies to use
Gradle Version Catalogs will not be used because of 7.4+ gradle version, unstable API, imposibility to use buildSrc in settings.gradle